### PR TITLE
Preserving Entity Fuzziness

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-CLA# OpenCalais
+# OpenCalais
 
 [![License](https://img.shields.io/badge/license-MIT-blue.svg)](http://opensource.org/licenses/MIT)
 [![Build Status](https://travis-ci.org/PRX/open_calais.svg?branch=master)](https://travis-ci.org/PRX/open_calais)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# OpenCalais
+CLA# OpenCalais
 
 [![License](https://img.shields.io/badge/license-MIT-blue.svg)](http://opensource.org/licenses/MIT)
 [![Build Status](https://travis-ci.org/PRX/open_calais.svg?branch=master)](https://travis-ci.org/PRX/open_calais)

--- a/lib/open_calais/client.rb
+++ b/lib/open_calais/client.rb
@@ -43,7 +43,7 @@ module OpenCalais
       response = connection(options).post do |request|
         request.body = text
       end
-      OpenCalais::Response.new(response)
+      OpenCalais::Response.new(response, options)
     end
 
     # using analyze as a standard method name

--- a/lib/open_calais/connection.rb
+++ b/lib/open_calais/connection.rb
@@ -41,9 +41,10 @@ module OpenCalais
         connection.request  :url_encoded
         connection.response :mashify
         connection.response :logger if ENV['DEBUG']
+        connection.response :raise_error
 
         if opts[:headers][OpenCalais::HEADERS[:output_format]] == OpenCalais::OUTPUT_FORMATS[:json]
-          connection.response :json
+          connection.response :json, :content_type => /\bjson$/
         else
           connection.response :xml
         end

--- a/lib/open_calais/response.rb
+++ b/lib/open_calais/response.rb
@@ -4,11 +4,16 @@ require 'active_support'
 
 module OpenCalais
   class Response
+    
+    ALLOWED_OPTIONS = [
+      :exact
+    ].freeze
 
     include ActiveSupport::Inflector
     attr_accessor :raw, :language, :topics, :tags, :entities, :relations, :locations
 
-    def initialize(response)
+    def initialize(response, options={})
+      @options = merge_default_options(options)
       @raw  = response
 
       @language = 'English'
@@ -18,7 +23,15 @@ module OpenCalais
       @relations = []
       @locations = []
 
-      parse(response)
+      parse(response, @options)
+    end
+    
+    def merge_default_options(opts={})
+      defaults = {
+        exact: true
+      }
+      options = defaults.merge(opts)
+      options.select{ |k,v| ALLOWED_OPTIONS.include? k.to_sym }
     end
 
     def humanize_topic(topic)
@@ -33,7 +46,7 @@ module OpenCalais
       end
     end
 
-    def parse(response)
+    def parse(response, options={})
       r = response.body
       @language = r.doc.meta.language rescue nil
       @language = nil if @language == 'InputTextTooShort'

--- a/lib/open_calais/response.rb
+++ b/lib/open_calais/response.rb
@@ -60,7 +60,7 @@ module OpenCalais
         when 'entities'
           item = {:guid => k, :name => v.name, :type => transliterate(v._type).titleize, :score => v.relevance}
 
-          instances = unless exact
+          instances = unless options[:exact]
             Array(v.instances)
           else
             Array(v.instances).select{|i| i.exact.downcase != item[:name].downcase }

--- a/lib/open_calais/response.rb
+++ b/lib/open_calais/response.rb
@@ -47,8 +47,12 @@ module OpenCalais
         when 'entities'
           item = {:guid => k, :name => v.name, :type => transliterate(v._type).titleize, :score => v.relevance}
 
-          instances = Array(v.instances).select{|i| i.exact.downcase != item[:name].downcase }
-          item[:matches] = instances if instances && instances.size > 0
+          instances = unless exact
+            Array(v.instances)
+          else
+            Array(v.instances).select{|i| i.exact.downcase != item[:name].downcase }
+          end
+          item[:matches] = instances unless instances.empty?
 
           if OpenCalais::GEO_TYPES.include?(v._type)
             if (v.resolutions && v.resolutions.size > 0)


### PR DESCRIPTION
Hey PRX folks!  Hello from DocumentCloud!

We were doing some final testing in our switch away from Calais old API and noticed that your Calais gem knocks out any match that doesn't literally match the entity name.

So, here's a pull request that preserves the existing behavior but provides an option to get all of the entity data.
