### PR TITLE
Make sure item[:name] will always have a value

### DIFF
--- a/lib/open_calais/response.rb
+++ b/lib/open_calais/response.rb
@@ -45,6 +45,7 @@ module OpenCalais
         when 'socialTag'
           self.tags << {:name => v.name.gsub('_', ' and ').downcase, :score => importance_to_score(v.importance)}
         when 'entities'
+          v.name = v.instances.first[:exact] if v.name.nil?
           item = {:guid => k, :name => v.name, :type => transliterate(v._type).titleize, :score => v.relevance}
 
           instances = Array(v.instances).select{|i| i.exact.downcase != item[:name].downcase }


### PR DESCRIPTION
In rare situations item (see https://github.com/PRX/open_calais/blob/master/lib/open_calais/response.rb#L50) might not have field `:name`. To prevent such situations we make sure that it takes `exact` value by extracting it from first item of `instances` array when name field is `nil`
