### PR TITLE
update to new API endpoint

### DIFF
--- a/lib/open_calais/configuration.rb
+++ b/lib/open_calais/configuration.rb
@@ -17,7 +17,7 @@ module OpenCalais
     DEFAULT_ADAPTER = :excon
 
     # The api endpoint to get REST info from opencalais
-    DEFAULT_ENDPOINT = 'https://api.thomsonreuters.com/permid/calais'.freeze
+    DEFAULT_ENDPOINT = 'https://api-eit.refinitiv.com/permid/calais'.freeze
 
     # The value sent in the http header for 'User-Agent' if none is set
     DEFAULT_USER_AGENT = "OpenCalais Ruby Gem #{OpenCalais::VERSION}".freeze


### PR DESCRIPTION
The old endpoint no longer works.  Per the email Refinitiv sent out:

> 	
 
 
 
To all users of Open Calais and Open PermID (permid.org) application programming interfaces (APIs)

As most of you will know from previous notifications, the Open Calais and Open PermID APIs will no longer be supported via the old https://api.thomsonreuters.com URL. Please switch to using the new URL https://api-eit.refinitiv.com before June 15th 2020, to continue to use these APIs.

Please note this only applies to the Open Calais and Open PermID products. No other Refinitiv or Thomson Reuters products or services are affected.


Example
 

If you are currently accessing the Calais tagging API using this URL:

https://api.thomsonreuters.com/permid/calais

update your application(s) to use the following URL:

https://api-eit.refinitiv.com/permid/calais


Further information

If you have any questions, please use the Q&A section of the Developer Community.

Thank you again for being part of our growing community of users.

Regards,
Refinitiv Product Management