### PR TITLE
Preserving Entity Fuzziness ||

### DIFF
--- a/lib/open_calais/client.rb
+++ b/lib/open_calais/client.rb
@@ -43,7 +43,7 @@ module OpenCalais
       response = connection(options).post do |request|
         request.body = text
       end
-      OpenCalais::Response.new(response)
+      OpenCalais::Response.new(response, options)
     end
 
     # using analyze as a standard method name

--- a/lib/open_calais/connection.rb
+++ b/lib/open_calais/connection.rb
@@ -47,9 +47,10 @@ module OpenCalais
         connection.request  :url_encoded
         connection.response :mashify
         connection.response :logger if ENV['DEBUG']
+        connection.response :raise_error
 
         if opts[:headers][OpenCalais::HEADERS[:output_format]] == OpenCalais::OUTPUT_FORMATS[:json]
-          connection.response :json
+          connection.response :json, :content_type => /\bjson$/
         else
           connection.response :xml
         end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,11 +1,11 @@
 # -*- encoding: utf-8 -*-
 
-require 'simplecov'
-SimpleCov.start
-
 if ENV['TRAVIS']
   require 'coveralls'
   Coveralls.wear!
+else
+  require 'simplecov'
+  SimpleCov.start
 end
 
 require 'minitest/autorun'


### PR DESCRIPTION
This is based on #10 from @documentcloud from @knowtheory 
It does basically the same thing, but the flag is now named  `:ignore_literal_match`.
When this is set to true (default), then entity matches that are the same exact string are ignored.
When set to false, all matches are returned.