### PR TITLE
explicitly check for nil

### DIFF
--- a/lib/open_calais/response.rb
+++ b/lib/open_calais/response.rb
@@ -103,7 +103,7 @@ module OpenCalais
     end
 
     def set_location_info(item, v)
-      return item if v.resolutions.empty?
+      return item if v.resolutions.nil? || v.resolutions.empty?
 
       r = v.resolutions.first
       item[:name]      = r.shortname || r.name


### PR DESCRIPTION
This change will prevent _**NoMethodError: undefined method `empty?' for nil:NilClass**_ errors.  I was getting many of those exceptions, depending on what text was being sent to be analyzed.